### PR TITLE
Improve frontend styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
     <title>DiagnoAssist</title>
   </head>
-  <body>
+  <body class="font-sans bg-gray-50">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,17 +35,24 @@ export default function App() {
   const prev = () => setCurrent((c) => Math.max(c - 1, 0));
 
   return (
-    <div className="container mx-auto max-w-2xl p-4">
-      <h1 className="text-2xl font-bold mb-4 text-center">DiagnoAssist</h1>
-      <StepNavigation steps={steps} current={current} />
+    <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
+      <div className="w-full max-w-2xl bg-white rounded-lg shadow p-6">
+        <h1 className="text-3xl font-bold mb-6 text-center text-blue-700">DiagnoAssist</h1>
+        <StepNavigation steps={steps} current={current} />
       {current === 0 && (
         <div className="space-y-4">
           <div>
             <label className="block mb-1 font-medium">Chief Complaint</label>
             <input
               className="border rounded w-full p-2"
+              placeholder="Describe the issue"
+              autoCorrect="on"
+              autoCapitalize="sentences"
+              spellCheck
               value={patientInfo.chiefComplaint}
-              onChange={(e) => setPatientInfo({ ...patientInfo, chiefComplaint: e.target.value })}
+              onChange={(e) =>
+                setPatientInfo({ ...patientInfo, chiefComplaint: e.target.value })
+              }
             />
           </div>
           <div>
@@ -53,8 +60,14 @@ export default function App() {
             <textarea
               className="border rounded w-full p-2"
               rows={4}
+              placeholder="Additional details"
+              autoCorrect="on"
+              autoCapitalize="sentences"
+              spellCheck
               value={patientInfo.details}
-              onChange={(e) => setPatientInfo({ ...patientInfo, details: e.target.value })}
+              onChange={(e) =>
+                setPatientInfo({ ...patientInfo, details: e.target.value })
+              }
             />
           </div>
         </div>
@@ -67,8 +80,14 @@ export default function App() {
             <textarea
               className="border rounded w-full p-2"
               rows={4}
+              placeholder="Past illnesses, surgeries, etc."
+              autoCorrect="on"
+              autoCapitalize="sentences"
+              spellCheck
               value={history.history}
-              onChange={(e) => setHistory({ ...history, history: e.target.value })}
+              onChange={(e) =>
+                setHistory({ ...history, history: e.target.value })
+              }
             />
           </div>
           <div>
@@ -76,8 +95,14 @@ export default function App() {
             <textarea
               className="border rounded w-full p-2"
               rows={3}
+              placeholder="Your notes"
+              autoCorrect="on"
+              autoCapitalize="sentences"
+              spellCheck
               value={history.observations}
-              onChange={(e) => setHistory({ ...history, observations: e.target.value })}
+              onChange={(e) =>
+                setHistory({ ...history, observations: e.target.value })
+              }
             />
           </div>
         </div>
@@ -90,22 +115,38 @@ export default function App() {
               <label className="block mb-1 font-medium">Blood Pressure</label>
               <input
                 className="border rounded w-full p-2"
+                placeholder="120/80"
+                autoCorrect="on"
+                autoCapitalize="off"
+                spellCheck
                 value={exam.bloodPressure}
-                onChange={(e) => setExam({ ...exam, bloodPressure: e.target.value })}
+                onChange={(e) =>
+                  setExam({ ...exam, bloodPressure: e.target.value })
+                }
               />
             </div>
             <div>
               <label className="block mb-1 font-medium">Heart Rate</label>
               <input
                 className="border rounded w-full p-2"
+                placeholder="beats/min"
+                autoCorrect="on"
+                autoCapitalize="off"
+                spellCheck
                 value={exam.heartRate}
-                onChange={(e) => setExam({ ...exam, heartRate: e.target.value })}
+                onChange={(e) =>
+                  setExam({ ...exam, heartRate: e.target.value })
+                }
               />
             </div>
             <div>
               <label className="block mb-1 font-medium">Height</label>
               <input
                 className="border rounded w-full p-2"
+                placeholder="cm"
+                autoCorrect="on"
+                autoCapitalize="off"
+                spellCheck
                 value={exam.height}
                 onChange={(e) => setExam({ ...exam, height: e.target.value })}
               />
@@ -114,6 +155,10 @@ export default function App() {
               <label className="block mb-1 font-medium">Weight</label>
               <input
                 className="border rounded w-full p-2"
+                placeholder="kg"
+                autoCorrect="on"
+                autoCapitalize="off"
+                spellCheck
                 value={exam.weight}
                 onChange={(e) => setExam({ ...exam, weight: e.target.value })}
               />
@@ -124,6 +169,10 @@ export default function App() {
             <textarea
               className="border rounded w-full p-2"
               rows={3}
+              placeholder="Any other findings"
+              autoCorrect="on"
+              autoCapitalize="sentences"
+              spellCheck
               value={exam.other}
               onChange={(e) => setExam({ ...exam, other: e.target.value })}
             />
@@ -146,6 +195,10 @@ export default function App() {
             <textarea
               className="border rounded w-full p-2"
               rows={3}
+              placeholder="Let us know if anything looks off"
+              autoCorrect="on"
+              autoCapitalize="sentences"
+              spellCheck
               value={feedback}
               onChange={(e) => setFeedback(e.target.value)}
             />
@@ -174,6 +227,9 @@ export default function App() {
                 <input
                   className="border rounded w-full p-2 mt-1"
                   placeholder="Result"
+                  autoCorrect="on"
+                  autoCapitalize="off"
+                  spellCheck
                   value={t.result}
                   onChange={(e) => {
                     const newTests = [...tests];
@@ -193,6 +249,10 @@ export default function App() {
           <textarea
             className="border rounded w-full p-2"
             rows={4}
+            placeholder="Enter your working diagnosis"
+            autoCorrect="on"
+            autoCapitalize="sentences"
+            spellCheck
             value={finalDx}
             onChange={(e) => setFinalDx(e.target.value)}
           />
@@ -230,6 +290,7 @@ export default function App() {
           </button>
         )}
       </div>
+    </div>
     </div>
   );
 }

--- a/frontend/src/components/StepNavigation.tsx
+++ b/frontend/src/components/StepNavigation.tsx
@@ -5,9 +5,27 @@ interface StepNavigationProps {
 
 export default function StepNavigation({ steps, current }: StepNavigationProps) {
   return (
-    <ol className="flex space-x-2 mb-4">
+    <ol className="flex items-center mb-6">
       {steps.map((step, index) => (
-        <li key={index} className={`flex-1 px-2 py-1 text-center rounded-full text-sm ${index === current ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}>{step}</li>
+        <li key={step} className="flex items-center w-full">
+          <div
+            className={`flex items-center justify-center w-8 h-8 rounded-full text-sm font-medium ${
+              index <= current ? 'bg-blue-600 text-white' : 'bg-gray-300 text-gray-600'
+            }`}
+          >
+            {index + 1}
+          </div>
+          <span
+            className={`ml-2 text-sm sm:text-base ${
+              index === current ? 'text-blue-600 font-semibold' : 'text-gray-600'
+            }`}
+          >
+            {step}
+          </span>
+          {index < steps.length - 1 && (
+            <div className="flex-1 h-px bg-gray-300 mx-2" />
+          )}
+        </li>
       ))}
     </ol>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gray-50 font-sans;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,7 +4,11 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui']
+      }
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- modernize the look and feel of the React frontend
- use Inter font and new progress bar design
- enhance input fields with placeholders and spellcheck

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843bad30f548323a7cc8503d0c58e95